### PR TITLE
Revert "travis build matrix fix"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       - sudo tlmgr install framed
       - sudo tlmgr install titling
    - os: osx
-     disable_homebrew: false
+     disable_homebrew: true
      r: devel
      r_packages:
       - coda
@@ -23,9 +23,6 @@ matrix:
       - plyr
       - RColorBrewer
       - truncdist
-      - knitr
-      - rmarkdown
-      - testthat
      sudo: required
      before_install:
       - curl -O http://r.research.att.com/libs/gfortran-4.8.2-darwin13.tar.bz2
@@ -42,4 +39,6 @@ matrix:
      r_packages: covr
      sudo: required
      after_success: Rscript -e 'covr::codecov()'
+ allow_failures:
+  - os: osx
 warnings_are_errors: true


### PR DESCRIPTION
Reverts pboesu/debinfer#18 
squash and commit disables automatic merging of upstream commits on development branch
